### PR TITLE
Refactor the instance formatting process and add the results of COPA

### DIFF
--- a/dataset/copa.py
+++ b/dataset/copa.py
@@ -15,33 +15,34 @@ class Copa(MultipleChoiceDataset):
         label: 1
     """
 
-    def __init__(self, args):
+    def __init__(self, args, model):
         self.name = "copa"
         # dataset = load_dataset("super_glue", "copa")
-        dataset = load_from_disk("copa")
+        dataset = load_from_disk("../dataset/copa")
         self.example_data = list(dataset[args.example_set])
         self.evaluation_data = list(dataset[args.evaluation_set])
+        self.instruction = "Complete the following the sentence."
 
-        super().__init__(args)
+        super().__init__(args, model)
 
     def format_instance(self, instance):
-        source_text = instance["premise"][:-1]
+        source = instance["premise"][:-1]
         if instance["question"] == "cause":
-            source_text += " because"
+            source += " because"
         elif instance["question"] == "effect":
-            source_text += " therefore"
+            source += " therefore"
 
         label2text = {
-            -1: "",
             0: " " + instance["choice1"][0].lower() + instance["choice1"][1:],
             1: " " + instance["choice2"][0].lower() + instance["choice2"][1:],
         }
 
-        options = []
-        for option in [0, 1]:
-            target_text = label2text[option]
-            options.append((source_text, target_text))
-        return dict(ground_truth=(source_text, label2text[instance['label']]), options=options)
+        options = [label2text[option] for option in [0, 1]]
+        return dict(
+            source=source,
+            target=label2text[instance['label']],
+            options=options,
+        )
 
     @property
     def references(self):

--- a/dataset/multiple_choice_dataset.py
+++ b/dataset/multiple_choice_dataset.py
@@ -9,8 +9,8 @@ class MultipleChoiceDataset(Dataset):
     evaluation_type = "ranking"
     metric = "accuracy"
 
-    def __init__(self, args):
-        super().__init__(args)
+    def __init__(self, args, model):
+        super().__init__(args, model)
 
     def calculate_metric(self, predictions):
         score_list = np.asarray(predictions) == np.asarray(self.references)

--- a/dataset/utils.py
+++ b/dataset/utils.py
@@ -1,15 +1,16 @@
 import importlib
 
 
-def load_dataset(args):
+def load_dataset(args, model):
     r"""Load corresponding dataset class.
 
     Args:
         args (Namespace): The global configurations.
+        model (Model): Our class for model.
 
     Returns:
         Dataset: Our class for dataset.
     """
     dataset = importlib.import_module(f"dataset.{args.dataset}")
-    dataset = getattr(dataset, args.dataset.capitalize())(args)
+    dataset = getattr(dataset, args.dataset.capitalize())(args, model)
     return dataset

--- a/evaluator.py
+++ b/evaluator.py
@@ -21,8 +21,7 @@ class Evaluator:
         self.args = args
 
         self.model = load_model(args)
-        args.tokenizer = self.model.tokenizer
-        self.dataset = load_dataset(args)
+        self.dataset = load_dataset(args, self.model)
         # TODO: change to logger
         # filename = args.model + "-" + args.dataset + "-" + str(args.num_shots)
         # self.args.filename = filename

--- a/model/model.py
+++ b/model/model.py
@@ -6,11 +6,14 @@ class Model:
     
     Attributes:
         name (str): The name of this model.
+        type (str): The type of this model, which can be chosen from `base` and `instruction`.
         tokenizer (Union[transformers.PreTrainedTokenizer, tiktoken.Encoding]): The tokenizer of this model.
         max_tokens (int): The maximum token length of this model.
         generation_kwargs (dict): The configurations for open-ended generation.
         ppl_kwargs (dict, *optional*): The configurations for computing PPL score.
     """
+    name = ""
+    type = ""
 
     def __init__(self, args):
         self.args = args

--- a/model/openai.py
+++ b/model/openai.py
@@ -17,6 +17,7 @@ class Openai(Model):
         super().__init__(args)
         openai.api_key = os.environ.get("OPENAI_API_SECRET_KEY") or args.openai_api_key
         self.name = args.model
+        self.type = "base"
         # TODO: compatible for gpt-3.5-turbo
         self.tokenizer = tiktoken.get_encoding("r50k_base")
         # TODO: compatible for gpt-3.5-turbo (enum_type?)

--- a/utils.py
+++ b/utils.py
@@ -13,11 +13,19 @@ def parse_argument():
     parser.add_argument("-bsz", "--batch_size", type=int, default=1, help="The evaluation batch size")
     parser.add_argument("--evaluation_set", type=str, default="validation", help="The set name for evaluation")
     parser.add_argument("--seed", type=int, default=2023, help="The random seed")
-    parser.add_argument("-inst", "--instruction", type=str, default="", help="The instruction to format each instance")
+    parser.add_argument("-sys", "--system_prompt", type=str, default="", help="The system prompt of the model")
+    parser.add_argument(
+        "-format",
+        "--instance_format",
+        type=str,
+        default="{source}{target}",
+        help="The format to format the `source` and `target` for each instance"
+    )
     parser.add_argument("--example_set", type=str, default="train", help="The set name for demonstration")
     parser.add_argument("-shots", "--num_shots", type=int, default=0, help="The few-shot number for demonstration")
-    parser.add_argument("--max_example_tokens", type=int, default=1024, help="The maximum token number of demonstration")
-    parser.add_argument("--example_separator_string", type=str, default="\n\n", help="The string to separate each demonstration")
+    parser.add_argument(
+        "--max_example_tokens", type=int, default=1024, help="The maximum token number of demonstration"
+    )
     parser.add_argument("-api", "--openai_api_key", type=str, default="", help="The OpenAI API key")
 
     args, unparsed = parser.parse_known_args()


### PR DESCRIPTION
- Copa
  - zero-shot
  ```bash
  python inference.py -m curie -d copa -shots 0
  ```
  Our results: 79.0. Paper results: 80.0.
  
  - one-shot
  ```bash
  python inference.py -m curie -d copa -shots 1
  ```
  Our results: 77.0. Paper results: 82.0.
  
  - zero-shot
  ```bash
  python inference.py -m curie -d copa -shots 32
  ```
  Our results: 83.0. Paper results: 83.0.