### PR TITLE
fix bugs of Coqa

### DIFF
--- a/llm_box/dataset/coqa.py
+++ b/llm_box/dataset/coqa.py
@@ -53,7 +53,7 @@ class Coqa(GenerationDataset):
     def _load_raw_dataset(self, dataset_path, subset_name, evaluation_set, example_set):
         evaluation_dataset = json.load(open("coqa-dev-v1.0.json"))["data"]
         example_dataset = json.load(open("coqa-train-v1.0.json"))["data"]
-        self.evaluation_data = self.convert(evaluation_dataset, "dev")[:300]
+        self.evaluation_data = self.convert(evaluation_dataset, "dev")
         self.example_data = self.convert(example_dataset, "train")
 
     @staticmethod


### PR DESCRIPTION
- Coqa 300
- zero-shot
```bash
python inference.py -m curie -d coqa -shots 0 --max_tokens 64
```
Our F1 results: 71.17. Paper results: 72.8. Our EM results: 54.33. 
- one-shot
```bash
python inference.py -m curie -d coqa -shots 1 --max_tokens 64
```
Our F1 results: 70.76. Paper results: 75.1. Our EM results: 56.08. 
- few-shot
```bash
python inference.py -m curie -d coqa -shots 5 --max_tokens 64
```
Our F1 results: 70.76. Paper results: 77.3. Our EM results: 56.08. 