### PR TITLE
Add Story_cloze dataset

### DIFF
--- a/llmbox/dataset/story_cloze.py
+++ b/llmbox/dataset/story_cloze.py
@@ -1,0 +1,48 @@
+from .multiple_choice_dataset import MultipleChoiceDataset
+
+
+class Story_cloze(MultipleChoiceDataset):
+    """The dataset of storycloze.
+
+    Story Cloze Test' is a new commonsense reasoning framework for evaluating story understanding, story generation, and script learning.This test requires a system to choose the correct ending to a four-sentence story.
+
+    Example:
+        context: Mary wanted to go to work. She got into her car and drove on the highway. She realized she forgot her lunch and turned around to go back and get it. She went back home and got her lunch. She then drove to work.
+        endings: "[\", Mary got into her car and drove to work.\", \", Mary got into her car and drove to the store.\", \", Mary got into her car and drove to the airport.\", \", Mary got into her car and drove to the hospital.\"]",
+        label: 0,
+    """
+
+    instruction = ""
+    evaluation_set = "test"
+    example_set = "validation"
+    """
+     Because of the dataset policy, we can't download the dataset automatically, so we need to download it manually and load it from the local disk.
+
+     Please follow the manual download instructions:
+     To use Story Cloze you have to download it manually. Please fill this google form (http://goo.gl/forms/aQz39sdDrO). Complete the form. Then you will receive a download link for the dataset. Load it using: `--dataset_path /path/to/dataset`.
+    """
+    load_args = ("story_cloze", "2016")
+
+    def format_instance(self, instance):
+        instance["answer_right_ending"] = instance["answer_right_ending"] - 1
+
+        source = (
+            instance["input_sentence_1"] + " " + instance["input_sentence_2"] + " " + instance["input_sentence_3"] +
+            " " + instance["input_sentence_4"]
+        )
+
+        label2text = {
+            0: " " + instance["sentence_quiz1"][0] + instance["sentence_quiz1"][1:],
+            1: " " + instance["sentence_quiz2"][0] + instance["sentence_quiz2"][1:],
+        }
+
+        options = [label2text[option] for option in (0, 1)]
+        return dict(
+            source=source,
+            target=label2text[instance["answer_right_ending"]],
+            options=options,
+        )
+
+    @property
+    def references(self):
+        return [instance["answer_right_ending"] for instance in self.evaluation_data]

--- a/llmbox/dataset/utils.py
+++ b/llmbox/dataset/utils.py
@@ -19,7 +19,9 @@ EXTENDED_SEARCH_PATHS = [
 
 
 def accepts_subset(
-    load_args: Union[Tuple[str], Tuple[str, str], Tuple[()]], overwrite_subset: bool = True, subset: str = ""
+    load_args: Union[Tuple[str], Tuple[str, str], Tuple[()]],
+    overwrite_subset: bool = True,
+    subset: str = "",
 ) -> bool:
     if len(load_args) == 2 and isinstance(load_args[1], str):
         if overwrite_subset or load_args[1] == subset:
@@ -38,7 +40,10 @@ def get_raw_dataset_loader(
     subset_name: Optional[str],
     load_args: Optional[Union[Tuple[str], Tuple[str, str], Tuple[()]]],
     return_msg: bool = False,
-) -> Union[Callable[[Optional[str]], datasets.Dataset], Tuple[Callable[[str], datasets.Dataset], str]]:
+) -> Union[
+    Callable[[Optional[str]], datasets.Dataset],
+    Tuple[Callable[[str], datasets.Dataset], str],
+]:
     """Get the function to load the raw dataset from huggingface (if `load_args` is not None) or local path (if `dataset_path` is not None).
 
     ```python
@@ -81,7 +86,12 @@ def get_raw_dataset_loader(
             elif subset_name in infos:
 
                 def load_fn(split):
-                    return datasets.load_dataset(dataset_path, subset_name, split=split, trust_remote_code=True)
+                    return datasets.load_dataset(
+                        dataset_path,
+                        subset_name,
+                        split=split,
+                        trust_remote_code=True,
+                    )
 
             else:
                 raise ValueError(
@@ -98,6 +108,18 @@ def get_raw_dataset_loader(
 
             def load_fn(split):
                 return datasets.load_from_disk(os.path.join(dataset_path, subset_name))[split]
+
+        # for those datasets that is in huggingface but should be downloaded manually
+        elif os.path.isdir(dataset_path):
+
+            def load_fn(split):
+                return datasets.load_dataset(
+                    dataset_name,
+                    subset_name,
+                    split=split,
+                    data_dir=dataset_path,
+                    trust_remote_code=True,
+                )
 
         # load from a file
         else:


### PR DESCRIPTION
- zero-shot
```bash
python inference.py -m davinci-002 -d story_cloze:2016 --evaluation_set test\[:500\] -b 20 -shots 0 --dataset_path tests/datasets/story_cloze
```
Our results: 83.4. Paper results: 83.2.
- one-shot
```bash
python inference.py -m davinci-002 -d story_cloze:2016 --evaluation_set test\[:500\] -b 20 -shots 1 --dataset_path tests/datasets/story_cloze
```
our results: 83.4. Paper results: 84.7
- few-shot
```bash
python inference.py -m davinci-002 -d story_cloze:2016 --evaluation_set test\[:500\] -b 20 -shots 70 --dataset_path tests/datasets/story_cloze
```
our results: 86.6. Paper results: 87.7

Modified utils.py so that it can handle datasets that exists on huggingface while must be download manually(such as story_cloze, you need to download two .csv file and its build script will be created automatically)