### PR TITLE
add dataset BigBench penguins_in_a_table

### DIFF
--- a/llmbox/dataset/penguins_in_a_table.py
+++ b/llmbox/dataset/penguins_in_a_table.py
@@ -2,17 +2,16 @@ from .multiple_choice_dataset import MultipleChoiceDataset
 from ..metric import Accuracy
 import numpy as np
 
-class Penguins_in_a_table(MultipleChoiceDataset):
-    """The dataset of Copa.
 
-    The Choice Of Plausible Alternatives (COPA, Roemmele et al., 2011) dataset is a causal reasoning task in which a system is given a premise sentence and two possible alternatives.
+class Penguins_in_a_table(MultipleChoiceDataset):
+    """The dataset of Bigbench Penguins_in_a_table.
+
+    BIG-Bench but it doesn't require the hellish dependencies (tensorflow, pypi-bigbench, protobuf) of the official version.
 
     Example:
-        premise: The man turned on the faucet.
-        choice1: The toilet filled with water.
-        choice2: Water flowed from the spout.
-        question: effect
-        label: 1
+        inputs: Here is a table where the first line is a header and each subsequent line is a penguin: name, age, height (cm), weight (kg) Louis, 7, 50, 11 Bernard, 5, 80, 13 Vincent, 9, 60, 11 Gwen, 8, 70, 15 For example: the age of Louis is 7, the weight of Gwen is 15 kg, the height of Bernard is 80 cm. We now add a penguin to the table: James, 12, 90, 12 And here is a similar table, but listing giraffes: name, age, height (cm), weight (kg) Jody, 5, 430, 620 Gladys, 10, 420, 590 Marian, 2, 310, 410 Donna, 9, 440, 650 Which is the oldest penguin? Answer:	
+        multiple_choice_targets: [ "Louis", "Bernard", "Vincent", "Gwen", "James" ]
+        multiple_choice_scores: [ 0, 0, 0, 0, 1 ]
     """
 
     instruction = ""

--- a/llmbox/dataset/penguins_in_a_table.py
+++ b/llmbox/dataset/penguins_in_a_table.py
@@ -1,0 +1,36 @@
+from .multiple_choice_dataset import MultipleChoiceDataset
+from ..metric import Accuracy
+import numpy as np
+
+class Penguins_in_a_table(MultipleChoiceDataset):
+    """The dataset of Copa.
+
+    The Choice Of Plausible Alternatives (COPA, Roemmele et al., 2011) dataset is a causal reasoning task in which a system is given a premise sentence and two possible alternatives.
+
+    Example:
+        premise: The man turned on the faucet.
+        choice1: The toilet filled with water.
+        choice2: Water flowed from the spout.
+        question: effect
+        label: 1
+    """
+
+    instruction = ""
+    evaluation_set = "validation"
+    example_set = "train"
+    load_args = ("tasksource/bigbench", "penguins_in_a_table")
+    metrics = [Accuracy()]
+
+    def format_instance(self, instance):
+        source = instance["inputs"]
+        options = [" " + option for option in instance["multiple_choice_targets"]]
+        return dict(
+            source=source,
+            source_postfix="",
+            target_idx=int(np.argmax(instance["multiple_choice_scores"])),
+            options=options,
+        )
+
+    @property
+    def references(self):
+        return [int(np.argmax(instance["multiple_choice_scores"])) for instance in self.evaluation_data]


### PR DESCRIPTION
- BigBench penguins_in_a_table
 - zero-shot
  ```bash
  python inference.py -m davinci-002 -d penguins_in_a_table --evaluation_set validation -shots 0
  ```
  Our results: 34.48.
  
 - one-shot
  ```bash
  python inference.py -m davinci-002 -d penguins_in_a_table --evaluation_set validation -shots 1   
  ```
  Our results: 41.38.
  
 - two-shot
  ```bash
  python inference.py -m davinci-002 -d penguins_in_a_table --evaluation_set validation -shots 2  
  ```
  Our results: 41.38.
 - three-shot
  ```bash
  python inference.py -m davinci-002 -d penguins_in_a_table --evaluation_set validation -shots 3    
  ```
  Our results: 44.83.