### PR TITLE
add dataset Reasoning_about_color_objects

### DIFF
--- a/llmbox/dataset/color_objects.py
+++ b/llmbox/dataset/color_objects.py
@@ -4,7 +4,7 @@ from ..metric import Accuracy
 from .generation_dataset import GenerationDataset
 
 
-class Reasoning_about_color_objects(GenerationDataset):
+class Color_objects(GenerationDataset):
     """The dataset of BIG-Bench Reasoning_about_color_objects dataset.
 
     BIG-Bench but it doesn't require the hellish dependencies (tensorflow, pypi-bigbench, protobuf) of the official version.
@@ -40,7 +40,8 @@ class Reasoning_about_color_objects(GenerationDataset):
             refer = np.array(instance["multiple_choice_targets"])
             idx = np.array(instance["multiple_choice_scores"])
             refer = refer[np.where(idx == 1)[0]]
-            new_predictions.append(True) if pred in refer else new_predictions.append(False)
+            print(pred,refer,pred in refer)
+            new_predictions.append(True if pred in refer else False)
         return new_predictions
 
     @property

--- a/llmbox/dataset/reasoning_about_color_objects.py
+++ b/llmbox/dataset/reasoning_about_color_objects.py
@@ -1,0 +1,48 @@
+import numpy as np
+import re
+from ..metric import Accuracy
+from .generation_dataset import GenerationDataset
+
+
+class Reasoning_about_color_objects(GenerationDataset):
+    """The dataset of BIG-Bench Reasoning_about_color_objects dataset.
+
+    BIG-Bench but it doesn't require the hellish dependencies (tensorflow, pypi-bigbench, protobuf) of the official version.
+
+    Example:
+        inputs: Q: On the floor, I see three silver keychains, three burgundy keychains, three burgundy teddy bears, three magenta teddy bears, three burgundy stress balls, and three magenta keychains. If I remove all the burgundy items from the floor, how many keychains remain on it? A:
+        targets: [ "6" ]
+        multiple_choice_targets: [ "0", "zero", "1", "one", "2", "two", "3", "three", "4", "four", "5", "five", "6", "six", "7", "seven", "8", "eight", "9", "nine", "10", "ten", "11", "eleven", "12", "twelve", "13", "thirteen", "14", "fourteen", "15", "fifteen", "16", "sixteen" ]
+        multiple_choice_scores: [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+    """
+
+    evaluation_set = "validation"
+    example_set = "train"
+    metrics = [Accuracy()]
+    instruction = ""
+    load_args = ("tasksource/bigbench", "reasoning_about_colored_objects")
+    extra_model_args = dict(temperature=0, stop=["\n"])
+
+    def format_instance(self, instance):
+        source_text = instance["inputs"]
+        target_text = " " + instance["targets"][0]
+        return dict(source=source_text, target=target_text)
+
+    def post_processing(self, predictions):
+        new_predictions = []
+        pattern = r"[.,!(\n)]"
+        for pred, instance in zip(predictions, self.evaluation_data):
+            pred = pred.lower().strip().split("\n")[0]
+            match = re.search(pattern, pred)
+            if match:
+                index = match.start()
+                pred = pred[:index]
+            refer = np.array(instance["multiple_choice_targets"])
+            idx = np.array(instance["multiple_choice_scores"])
+            refer = refer[np.where(idx == 1)[0]]
+            new_predictions.append(True) if pred in refer else new_predictions.append(False)
+        return new_predictions
+
+    @property
+    def references(self):
+        return [True for _ in self.evaluation_data]


### PR DESCRIPTION
- Reasoning_about_color_objects 200
 - zero-shot
  ```bash
python inference.py -m davinci-002 -d reasoning_about_color_objects --evaluation_set validation\[:200\] -shots 0
  ```
  Our results: 40.00.
  
 - one-shot
  ```bash
python inference.py -m davinci-002 -d reasoning_about_color_objects --evaluation_set validation\[:200\] -shots 1
  ```
  Our results: 48.50.
  
 - two-shot
  ```bash
python inference.py -m davinci-002 -d reasoning_about_color_objects --evaluation_set validation\[:200\] -shots 2
  ```
  Our results: 44.50.

 - three-shot
  ```bash
python inference.py -m davinci-002 -d reasoning_about_color_objects --evaluation_set validation\[:200\] -shots 3
  ```
  Our results: 44.00.