### PR TITLE
Add enum of tasks in agieval

### DIFF
--- a/utilization/dataset/enum.py
+++ b/utilization/dataset/enum.py
@@ -127,6 +127,21 @@ AGIEVAL_GAOKAO_TASK = [
 
 AGIEVAL_NO_LETTER_CHOICE = AGIEVAL_EN_CLOZE + AGIEVAL_ZH_CLOZE
 
+AGIEVAL_MULTIPLE_CHOICE_TASK = [
+    'lsat-ar', 'lsat-lr', 'lsat-rc',
+    'logiqa-en', 'sat-math', 'sat-en',
+    'aqua-rat', 'sat-en-without-passage', 'gaokao-english',
+    'logiqa-zh', 'gaokao-chinese', 'gaokao-chemistry',
+    'gaokao-geography', 'gaokao-history', 'gaokao-biology',
+    # 'gaokao-mathqa',    # due to the bugs in agieval dataset, we now treat gaokao-mathqa as generation.
+]
+
+AGIEVAL_GENERTION_TASK = [
+    'jec-qa-kd', 'jec-qa-ca', 'gaokao-physics',
+    'math', 'gaokao-mathcloze',
+    'gaokao-mathqa'    # due to the bugs in agieval dataset, we now treat gaokao-mathqa as generation.
+]
+
 CMMLU_NAME_TRANS = {
     "agronomy": "农学",
     "anatomy": "解剖学",


### PR DESCRIPTION
Provide the separation of generation and multiple choice dataset in agieval.
Now, when calling agieval, we should call `agieval_single_choice` in `AGIEVAL_MULTIPLE_CHOICE_TASK`, and call `agieval_cot` in `AGIEVAL_GENERTION_TASK`.
Also, Chain of Thought is valid only when calling `agieval_cot`.