### PR TITLE
Add Mrpc

### DIFF
--- a/utilization/dataset/mrpc.py
+++ b/utilization/dataset/mrpc.py
@@ -14,14 +14,13 @@ class Mrpc(MultipleChoiceDataset):
         label: 1
     """
 
-    instruction = "Determine whether the following 2 sentences are semantically equivalent.\n\n{{source}}{{'\n'+options if options}}\nAnswer: "
+    instruction = "Determine whether the following 2 sentences are semantically equivalent.\n\nsentence1: {{sentence1.strip()}}\nsentenc2: {{sentence2.strip()}}{{'\n'+options if options}}\nAnswer: "
     evaluation_set = "validation"
     example_set = "train"
     load_args = ("nyu-mll/glue", "mrpc")
 
     def format_instance(self, instance):
         instance["options"] = ["not_equivalent", "equivalent"]
-        instance["source"] = "sentence1: " + instance["sentence1"].strip() + "\nsentence 2: " + instance["sentence2"].strip()
         return instance
 
     @cached_property

--- a/utilization/dataset/mrpc.py
+++ b/utilization/dataset/mrpc.py
@@ -1,0 +1,29 @@
+from functools import cached_property
+
+from .multiple_choice_dataset import MultipleChoiceDataset
+
+
+class Mrpc(MultipleChoiceDataset):
+    """The dataset of Mrpc.
+
+    The Microsoft Research Paraphrase Corpus (Dolan & Brockett, 2005) is a corpus of sentence pairs automatically extracted from online news sources, with human annotations for whether the sentences in the pair are semantically equivalent.
+
+    Example:
+        sentence1: Amrozi accused his brother , whom he called " the witness " , of deliberately distorting his evidence .
+        sentence2: Referring to him as only " the witness " , Amrozi accused his brother of deliberately distorting his evidence .
+        label: 1
+    """
+
+    instruction = "Determine whether the following 2 sentences are semantically equivalent.\n\n{{source}}{{'\n'+options if options}}\nAnswer: "
+    evaluation_set = "validation"
+    example_set = "train"
+    load_args = ("nyu-mll/glue", "mrpc")
+
+    def format_instance(self, instance):
+        instance["options"] = ["not_equivalent", "equivalent"]
+        instance["source"] = "sentence1: " + instance["sentence1"].strip() + "\nsentence 2: " + instance["sentence2"].strip()
+        return instance
+
+    @cached_property
+    def references(self):
+        return [instance["label"] for instance in self.evaluation_data]


### PR DESCRIPTION
- Mrpc
- zero-shot
```bash
python inference.py -m Llama-2-7b-hf -d mrpc -shots 0 --ranking_type prob
```
Our results: 31.62.
```bash
python inference.py -m Meta-Llama-3-8B -d mrpc -shots 0 --ranking_type prob
```
Our results: 43.38.

- one-shot
```bash
python inference.py -m Llama-2-7b-hf -d mrpc -shots 1 --ranking_type prob
```
Our results: 46.32.
```bash
python inference.py -m Meta-Llama-3-8B -d mrpc -shots 1 --ranking_type prob
```
Our results: 69.61.

- 32-shot
```bash
python inference.py -m Llama-2-7b-hf -d mrpc -shots 32 --ranking_type prob
```
Our results: 42.65.
```bash
python inference.py -m Meta-Llama-3-8B -d mrpc -shots 32 --ranking_type prob
```
Our results: 69.85.

- prob is implemented in ranking type instead of get_pll, but identical prediction can not be avoid thoroughly, llama3 performs much better in this task