### PR TITLE
Add Sst2

### DIFF
--- a/tests/dry_test/test_datasets.py
+++ b/tests/dry_test/test_datasets.py
@@ -42,6 +42,7 @@ datasets = {
     "real_toxicity_prompts": None,
     "rte": [],
     "siqa": [],
+    "sst2": [],
     "squad": [],
     "squad_v2": [],
     "story_cloze": None,

--- a/utilization/dataset/sst2.py
+++ b/utilization/dataset/sst2.py
@@ -1,0 +1,27 @@
+from functools import cached_property
+
+from .multiple_choice_dataset import MultipleChoiceDataset
+
+
+class Sst2(MultipleChoiceDataset):
+    """The dataset of Sst2.
+
+    The Stanford Sentiment Treebank consists of sentences from movie reviews and human annotations of their sentiment. The task is to predict the sentiment of a given sentence. It uses the two-way (positive/negative) class split, with only sentence-level labels.
+
+    Example:
+        sentence: hide new secretions from the parental units
+        label: 1
+    """
+
+    instruction = "Determine the sentiment of the following sentence.\n{{sentence.strip()}}{{ '\n' + options if options }}\nAnswer:"
+    evaluation_set = "validation"
+    example_set = "train"
+    load_args = ("nyu-mll/glue", "sst2")
+
+    def format_instance(self, instance):
+        instance["options"] = ["negative", "positive"]
+        return instance
+
+    @cached_property
+    def references(self):
+        return [instance["label"] for instance in self.evaluation_data]


### PR DESCRIPTION
- Sst2

- choices: [negative, positive]
- zero-shot
```bash
python inference.py -m Llama-2-7b-hf -d sst2 -shots 0 --ranking_type prob
```
Our results: 59.75.
```bash
python inference.py -m Meta-Llama-3-8B -d sst2 -shots 0 --ranking_type prob
```
Our results: 74.89.

- one-shot
```bash
python inference.py -m Llama-2-7b-hf -d sst2 -shots 1 --ranking_type prob
```
Our results: 49.08.
```bash
python inference.py -m Meta-Llama-3-8B -d sst2 -shots 1 --ranking_type prob
```
Our results: 92.43.

- 32-shot
```bash
python inference.py -m Llama-2-7b-hf -d sst2 -shots 32 --ranking_type prob
```
Our results: 87.16.
```bash
python inference.py -m Meta-Llama-3-8B -d sst2 -shots 32 --ranking_type prob
```
Our results: 94.72.